### PR TITLE
Arnold crypto layer parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,45 @@ Decoders:
 
 ## Release Notes
 
+### [1.2.0+wwfx.1.2.0] - 2019-12-16
+
+Patched in Arnold style AOV layer names to cryptomattes parser, effectively
+doing the job of `CryptomatteMetadata` for any `CryptomatteWWFX*` named nodes.
+
+#### Added
+
+- `CryptoMatteInfo.setup_wwfx_arnold_layers()` called during `__init__`
+- `CryptomatteWWFX` menu item which calls new
+  `cryptomatte_utilities.wwfx_cryptomatte_create_gizmo()`
+
+#### Fixed
+
+- Missing numbering for `CryptomatteMetadata` nodes.
+- Missing WWFX change logs of previous versions.
+
+
+### [1.2.0+wwfx.1.1.1] - 2019-12-13
+
+Refactored to use `nuke.this*()` fallback and fixed callback method names.
+
+#### Fixed
+
+- Missing nuke node/knob causing "ValueError: A PythonObject is not attached
+  to a node".
+- Actually branch from Psyop 1.2.0
+
+
+### [1.2.0+wwfx.1.1.0] - 2019-12-13
+
+New `CryptomatteMetadata` node to fix Katana render outputs, using WWFX
+GitHub fork.
+
+#### Added
+
+- `CryptomatteMetadata` gizmo.
+
+------
+
 1.2.0:
 
 This is a major update to both the Nuke plugins and Fusion plugins, and a minor update to the Cryptomatte specification. 

--- a/nuke/CryptomatteMetadata.gizmo
+++ b/nuke/CryptomatteMetadata.gizmo
@@ -11,7 +11,7 @@ ModifyMetaData {
   {set exr/cryptomatte/bda530a/hash MurmurHash3_32}
   {set exr/cryptomatte/bda530a/name crypto_material_crypto_material}
  }
- name CryptomatteMetadata
+ name CryptomatteMetadata1
  tile_color 0xff00ff
  selected true
 }

--- a/nuke/cryptomatte_utilities.py
+++ b/nuke/cryptomatte_utilities.py
@@ -415,7 +415,7 @@ def cryptomatte_create_gizmo():
 
 
 def wwfx_cryptomatte_create_gizmo():
-    """
+    """Create Cryptomatte gizmo with WWFX in name for Arnold layer parsing.
 
     Returns:
         nuke.Node: Cryptomatte node with WWFX in name.

--- a/nuke/cryptomatte_utilities.py
+++ b/nuke/cryptomatte_utilities.py
@@ -356,7 +356,7 @@ class CryptomatteInfo(object):
         return errors, collisions
 
     def setup_wwfx_arnold_layers(self):
-        """Parse and update Arnold style `crypto_*` layers if WWFX in name.
+        """Parse and update Arnold style ``crypto_*`` layers if WWFX in name.
 
         Returns:
             str: Crypto ID from Arnold layers to use as default selection ID.

--- a/nuke/cryptomatte_utilities.py
+++ b/nuke/cryptomatte_utilities.py
@@ -31,12 +31,12 @@ def setup_cryptomatte_ui():
         toolbar = nuke.menu("Nodes")
         automatte_menu = toolbar.addMenu("Cryptomatte", "cryptomatte_logo.png",index=-1)
         automatte_menu.addCommand("Cryptomatte", "import cryptomatte_utilities as cu; cu.cryptomatte_create_gizmo();")
-        automatte_menu.addCommand("CryptomatteWWFX", "import cryptomatte_utilities as cu; cu.wwfx_cryptomatte_create_gizmo();")
         automatte_menu.addCommand("Decryptomatte All", "import cryptomatte_utilities as cu; cu.decryptomatte_all();")
         automatte_menu.addCommand("Decryptomatte Selection", "import cryptomatte_utilities as cu; cu.decryptomatte_selected();")
         automatte_menu.addCommand("Encryptomatte", "import cryptomatte_utilities as cu; cu.encryptomatte_create_gizmo();")
         # Patched in our own commands/actions
         automatte_menu.addSeparator().action().setText('WWFX')
+        automatte_menu.addCommand("CryptomatteWWFX", "import cryptomatte_utilities as cu; cu.wwfx_cryptomatte_create_gizmo();")
         automatte_menu.addCommand("CryptomatteMetadata", "nuke.createNode('CryptomatteMetadata')")
 
 def setup_cryptomatte():
@@ -183,7 +183,6 @@ class CryptomatteInfo(object):
                 valid_selection = self.set_selection(selection_name)
                 if not valid_selection and not self.nuke_node.knob("cryptoLayerLock").getValue():
                     self.selection = default_selection
-
 
     def is_valid(self):
         """Checks that the selection is valid."""


### PR DESCRIPTION
### [1.2.0+wwfx.1.2.0] - 2019-12-16

Patched in Arnold style AOV layer names to cryptomattes parser, effectively
doing the job of `CryptomatteMetadata` for any `CryptomatteWWFX*` named nodes.

#### Added

- `CryptoMatteInfo.setup_wwfx_arnold_layers()` called during `__init__`
- `CryptomatteWWFX` menu item which calls new
  `cryptomatte_utilities.wwfx_cryptomatte_create_gizmo()`

#### Fixed

- Missing numbering for `CryptomatteMetadata` nodes.
- Missing WWFX change logs of previous versions.